### PR TITLE
chore: update gitignore

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,5 +1,4 @@
 /node_modules
-/public
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*


### PR DESCRIPTION
As we encourage, the use of [CRA](https://github.com/facebook/create-react-app) we should keep `frontend/public` in the repository